### PR TITLE
Remove deprecated members from upsert account, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,7 @@ await client.upsertAccount({
     array_of_values: ["value1", "value2"],
     key_with_empty_value: "",
     this_property_will_be_deleted: null,
-  },
-
-  // optional
-  members: [
-    { userId: "userId" }, // userID: Unique identifier for the user in your database
-    { userId: "userId" }
-  ]
+  }
 });
 ```
 

--- a/lib/Client.test.ts
+++ b/lib/Client.test.ts
@@ -610,9 +610,6 @@ describe("Client", () => {
             likesDog: "true",
             firstDogName: "Journy",
           },
-          members: [
-            { identification: { userId: "userId", email: "user1@user.com" } },
-          ],
         })
       );
 
@@ -626,7 +623,6 @@ describe("Client", () => {
           likesDog: "true",
           firstDogName: "Journy",
         },
-        members: [{ email: "user1@user.com", userId: "userId" }],
       });
 
       expect(propertiesClient.getLastRequest()).toEqual(expectedRequest);

--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -265,15 +265,6 @@ export class Client {
         properties: args.properties
           ? this.stringifyProperties(args.properties)
           : undefined,
-        members: args.members
-          ? args.members.map((member) => {
-              const user = new UserIdentified(member.userId, member.email);
-
-              return {
-                identification: this.getUserIdentification(user),
-              };
-            })
-          : undefined,
       })
     );
 
@@ -548,7 +539,6 @@ export interface UpsertAccountArguments {
   accountId?: string;
   domain?: string;
   properties?: Properties;
-  members?: { email?: string; userId?: string }[];
 }
 
 interface UserToAccountArguments {


### PR DESCRIPTION
In the future, the `members` argument will not longer be supported by the API. Therefore the SDK's should be updated accordingly. Please consider using `addUsersToAccount` and `removeUsersFromAccount`.